### PR TITLE
New methods:  forEachByKind and getChildrenByKindOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Properties with array values are treated one of two ways:
 - [x] getChildrenOf -- get an array of node IDs for the given parent ID
 - [x] getNode -- return the node data for a given ID
 - [x] getPathOf -- give the `Kind` path for a given node ID
+- [x] forEachByKind -- given a `Kind` execute the supplied function for all nodes of that kind 
 
 #### Manipulation
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ Properties with array values are treated one of two ways:
 
 #### Navigation
 
-- [x] getParentOf -- get parent ID from child ID, or `null` if not found
+- [x] parentIdOf -- get parent ID from child ID, or `null` if not found
 - [x] getChildrenOf -- get an array of node IDs for the given parent ID
+- [x] getChildrenByKindOf - get an array of child node IDs for a given parent where the child is a specified type
 - [x] getNode -- return the node data for a given ID
 - [x] getPathOf -- give the `Kind` path for a given node ID
 - [x] forEachByKind -- given a `Kind` execute the supplied function for all nodes of that kind 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-surgeon",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Tools for editing tree structures using a relational model",
   "main": "tree-surgeon.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-surgeon",
-  "version": "0.0.18",
+  "version": "0.0.17",
   "description": "Tools for editing tree structures using a relational model",
   "main": "tree-surgeon.js",
   "scripts": {

--- a/test/edit_by_kind_tests.js
+++ b/test/edit_by_kind_tests.js
@@ -3,23 +3,65 @@ var _ = require('lodash');
 
 var tree = require("../tree-surgeon.js");
 
-describe("Editing children by kind and filter function", function() {
-    it("should modify selected children but no other nodes", function(){
-        var input = {
-            "no":{"A":"B"},
-            "yes":{"A":"C"},
-            "neither":{"A":"D"}
-        };
-        var expected = {
-            "no":{"A":"B"},
-            "yes":{"A":"C", "Found":"C"},
-            "neither":{"A":"D"}
-        };
+describe("Iterating over defined sets", function() {
 
-        var result = tree.compose(
-            tree.editByKind("yes", function(n){n["Found"] = n["A"]; return n;},
-                tree.decompose(input)));
+    describe("Editing children by kind and filter function", function() {
+        it("should modify selected children but no other nodes", function(){
+            var input = {
+                "no":{"A":"B"},
+                "yes":{"A":"C"},
+                "neither":{"A":"D"}
+            };
+            var expected = {
+                "no":{"A":"B"},
+                "yes":{"A":"C", "Found":"C"},
+                "neither":{"A":"D"}
+            };
 
-        expect(result).to.deep.equal(expected);
+            var result = tree.compose(
+                tree.editByKind("yes", function(n){n["Found"] = n["A"]; return n;},
+                    tree.decompose(input)));
+
+            expect(result).to.deep.equal(expected);
+        });
+    });
+
+    describe("ForEach iteration by kind and predicate", function() {
+        it("should pass only selected children to the predicate but no other nodes", function() {
+            var input = {
+                'yes': {'name': 'First', 'keep': 'yes'},
+                'no': {'name': 'Second', 'keep': 'yes'},
+                'firstChildren': {
+                    'yes': {'name': 'Third', 'keep': 'yes'},
+                    'no': {'name': 'Forth', 'keep': 'yes'}
+                },
+                'secondChildren': {
+                    'yes': {'name': 'Fifth', 'keep': 'no'},
+                    'no': {'name': 'Sixth', 'keep': 'no'}
+                },
+                'cousins': {
+                    // Test array children
+                    'yes': [
+                        {'name': 'Seventh', 'keep': 'yes'},
+                        {'name': 'Eighth', 'keep': 'no'},
+                        {'name': 'Ninth', 'keep': 'yes'}
+                    ]
+                }
+            };
+            var expectedResult = ['First', 'Third', 'Seventh', 'Ninth'].sort();
+
+            var result = [];
+            var predicate = function (n, id) {
+                if (n.keep === 'yes') {
+                    result.push(n.name);
+                }
+            };
+
+            var relational = tree.decompose(input);
+            tree.forEachByKind('yes', predicate, relational);
+            result.sort();
+
+            expect(result).to.deep.equal(expectedResult);
+        });
     });
 });

--- a/test/navigation_tests.js
+++ b/test/navigation_tests.js
@@ -111,8 +111,73 @@ describe("Navigating relational structure", function(){
             expect(actual.length).to.equal(0);
             expect(actual).to.deep.equal([]);
         });
-
     });
+
+    describe("When getting the child IDs of children of s specific Kind given the parent ID", function() {
+        it("should give an empty array when passed an ID not in the relational structure", function(){
+            var input = {
+                "onlyChild" : {a:1}
+            };
+            var relational = tree.decompose(input);
+
+            var actual = tree.getChildrenByKindOf('ParentDoesntExist', 'nice', relational);
+
+            expect(actual.length).to.equal(0);
+            expect(actual).to.deep.equal([]);
+        });
+        it("should return an empty array if child Kind does not exists for parent", function() {
+            var input = {
+                'NotThis' : { 'name': 'no-one', 'match': 'no' },
+                'OnlyThis': { 'name': 'someone', 'match': 'yes' }
+            };
+
+            var relational = tree.decompose(input);
+            var actual = tree.getChildrenByKindOf(relational.Root, 'SomethingElse', relational);
+
+            expect(actual.length).to.equal(0);
+            expect(actual).to.deep.equal([]);
+        });
+        it("should return an array of a single child for a child object", function() {
+            var input = {
+                'NotThis' : { 'name': 'no-one', 'match': 'no' },
+                'OnlyThis': { 'name': 'someone', 'match': 'yes' }
+            };
+            var expected = ['someone'].sort();
+
+            var relational = tree.decompose(input);
+            var actualIds = tree.getChildrenByKindOf(relational.Root, 'OnlyThis', relational);
+            var actual = [];
+            actualIds.forEach(function(id) {
+                var node = tree.getNode(id, relational);
+                actual.push(node.name);
+            });
+
+            expect(actual.length).to.equal(1);
+            expect(actual.sort()).to.deep.equal(expected);
+        });
+        it("should return an array of children for an array object", function() {
+            var input = {
+                'OnlyThis': [
+                    { 'name': 'someone', 'match': 'yes' },
+                    { 'name': 'somewhere', 'match': 'yes' },
+                    { 'name': 'elsewhere', 'match': 'yes' },
+                ]
+            };
+            var expected = ['someone', 'somewhere', 'elsewhere'].sort();
+
+            var relational = tree.decompose(input);
+            var actualIds = tree.getChildrenByKindOf(relational.Root, 'OnlyThis', relational);
+            var actual = [];
+            actualIds.forEach(function(id) {
+                var node = tree.getNode(id, relational);
+                actual.push(node.name);
+            });
+
+            expect(actual.length).to.equal(3);
+            expect(actual.sort()).to.deep.equal(expected);
+        });
+    });
+
     describe("When getting the parent ID of a node by ID", function(){
         it("should give a single id where there is a parent", function(){
             var input = {

--- a/tree-surgeon.js
+++ b/tree-surgeon.js
@@ -164,11 +164,11 @@ var _ = require('lodash');
                 if (x[k] !== null && x[k] !== undefined) return false;
             }
             return true;
-        }
+        };
 
         var noChildren = function(k, rel) {
             return ! (_.some(rel.Relations, {Parent:k}));
-        }
+        };
 
         var cycleAgain = true;
         while (cycleAgain) {
@@ -379,6 +379,21 @@ var _ = require('lodash');
             var id = targetIds[i];
             relational.Nodes[id] = filterFunc(relational.Nodes[id], id);
         }
+        return relational;
+    };
+
+    /**
+     * Action the supplied function for each node of a specific kind
+     * @param kind -- the type of node to consider
+     * @param actionFunc -- function of (node, id) to execute for each matching node. Any return is ignored
+     * @param relational -- the source relational model (as created by decompose)
+     * @return a reference to the updated relational model
+     */
+    provides.forEachByKind = function(kind, actionFunc, relational) {
+        var targetIds = pickIdsByKind(kind, relational);
+        _.forEach(targetIds, function(id) {
+            actionFunc(relational.Nodes[id], id);
+        });
         return relational;
     };
 

--- a/tree-surgeon.js
+++ b/tree-surgeon.js
@@ -274,6 +274,12 @@ var _ = require('lodash');
         return relational;
     };
 
+    /** Remove nodes and their subtrees by node ID */
+    provides.chopNodesByIds = function(ids, relational) {
+        removeNodesByIds(relational, ids);
+        return relational;
+    };
+
     /** merge up by kind -- remove child nodes by relationship putting data into parent */
     provides.mergeUpByKind = function(kind, relational) {
         var parentGetsAll = function (n){return n;};
@@ -407,6 +413,19 @@ var _ = require('lodash');
         return _.pluck(_.where(relational.Relations, {Parent:parentId}), 'Child');
     };
 
+    /**
+     * getChildrenByKindOf
+     * Get a list of child IDs for the specified parent filtered by a specified Kind
+     * @param parentId -- the Id of the parent whose children should be checked
+     * @param kind -- the Kind of node to check for
+     * @param relational -- the source relational model (as created by decompose)
+     * @return an array of Child Id's of a specified Kind
+     */
+    provides.getChildrenByKindOf = function(parentId, kind, relational) {
+        var whereCriteria = {Parent: parentId, Kind: kind};
+        return _.pluck(_.where(relational.Relations, whereCriteria), 'Child' );
+    };
+
     /** return the Kind strings between root and the given node as an array  */
     provides.getPathOf = function(nodeId, relational) {
         var result = [];
@@ -420,12 +439,6 @@ var _ = require('lodash');
 
     /** get node data by id */
     provides.getNode = function(id, relational) {if (!relational) return undefined; else return relational.Nodes[id];};
-
-    /** Remove nodes and their subtrees by node ID */
-    provides.chopNodesByIds = function(ids, relational) {
-        removeNodesByIds(relational, ids);
-        return relational;
-    };
 
     // Return Child ids for a relation kind
     function pickIdsByKind(kind, relational) {


### PR DESCRIPTION
*Method: getChildrenByKindOf*
Get an array of child node IDs for a given parent where the child is a specified type

*Method: forEachByKind*
Calls the supplied predicate for each node of the specified Kind

Note: This version has already being published to npm